### PR TITLE
Filter info

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,12 @@ pvm help <command>
 # Display information about the current PHP (version, path, extensions, settings)
 pvm info # pvm ini info
 
+# Display information about the current PHP extensions
+pvm info extensions # pvm ini info extensions
+
+# Display information about the current PHP settings
+pvm info settings # pvm ini info settings
+
 # Display information about the current PHP (version, path, extensions, settings) with 'cache' in their name
 pvm info --search=<term> # pvm ini info --search=<term>
 # Example: pvm info --search=cache

--- a/src/actions/ini.ps1
+++ b/src/actions/ini.ps1
@@ -356,7 +356,12 @@ function Get-IniExtensionStatus {
 
 
 function Get-PHP-Info {
-    param ($term = $null)
+    param ($term = $null, $extensions = $false, $settings = $false)
+
+    if (-not $extensions -and -not $settings) {
+        $extensions = $true
+        $settings = $true
+    }
     
     $currentPHPVersion = Get-Current-PHP-Version
     
@@ -368,13 +373,19 @@ function Get-PHP-Info {
     Write-Host "`n- Running PHP version`t: $($currentPHPVersion.version)"
     Write-Host "`n- PHP path`t`t: $($currentPHPVersion.path)"
     $phpIniData = Get-PHP-Data -PhpIniPath "$($currentPHPVersion.path)\php.ini"
-    $extensions = $phpIniData.extensions | Where-Object { $_.Extension -like "*$term*" }
-    $settings = $phpIniData.settings | Where-Object { $_.Name -like "*$term*" }
-    Display-Extensions-States -extensions $phpIniData.extensions
-    Display-Installed-Extensions -extensions $extensions
-    Display-Settings-States -settings $phpIniData.settings
-    Display-Settings -settings $settings
-    
+
+    if ($extensions) {
+        $extensions = $phpIniData.extensions | Where-Object { $_.Extension -like "*$term*" }
+        Display-Extensions-States -extensions $phpIniData.extensions
+        Display-Installed-Extensions -extensions $extensions
+    }
+
+    if ($settings) {
+        $settings = $phpIniData.settings | Where-Object { $_.Name -like "*$term*" }
+        Display-Settings-States -settings $phpIniData.settings
+        Display-Settings -settings $settings
+    }
+
     return 0
 }
 
@@ -934,7 +945,7 @@ function Invoke-PVMIniAction {
         switch ($action) {
             "info" {
                 $term = ($params | Where-Object { $_ -match '^--search=(.+)$' }) -replace '^--search=', ''
-                $exitCode = Get-PHP-Info -term $term
+                $exitCode = Get-PHP-Info -term $term -extensions ($params -contains "extensions") -settings ($params -contains "settings")
             }
             "get" {
                 if ($params.Count -eq 0) {


### PR DESCRIPTION
Hello 👋🏻 

In this PR I have added the ability to filter current php info extensions / settings.

### Check extensions
This will show only extensions related informations about current PHP.
```bash
pvm info extensions
```

### Check settings
This will show only settings related informations about current PHP.
```bash
pvm info settings
```

