### PR TITLE
Add -NoProfile to elevated Run-Command subprocess

### DIFF
--- a/pvm.bat
+++ b/pvm.bat
@@ -10,9 +10,9 @@ set "ARGS=%ARGS:-- =%"
 
 where pwsh >nul 2>&1
 if %ERRORLEVEL%==0 (
-    pwsh -ExecutionPolicy Bypass -File "%FILE_TARGET%" %ARGS%
+    pwsh -NoProfile -ExecutionPolicy Bypass -File "%FILE_TARGET%" %ARGS%
 ) else (
-    powershell -ExecutionPolicy Bypass -File "%FILE_TARGET%" %ARGS%
+    powershell -NoProfile -ExecutionPolicy Bypass -File "%FILE_TARGET%" %ARGS%
 )
 
 endlocal

--- a/src/functions/helpers.ps1
+++ b/src/functions/helpers.ps1
@@ -212,7 +212,7 @@ function Make-Symbolic-Link {
 function Run-Command {
     param($command)
     
-    $process = Start-Process powershell -ArgumentList "-ExecutionPolicy Bypass -Command `"$command`"" -Verb RunAs -WindowStyle Hidden -PassThru -Wait
+    $process = Start-Process powershell -ArgumentList "-NoProfile -ExecutionPolicy Bypass -Command `"$command`"" -Verb RunAs -WindowStyle Hidden -PassThru -Wait
     $process.WaitForExit()
     return $process.ExitCode
 }

--- a/tests/helpers.tests.ps1
+++ b/tests/helpers.tests.ps1
@@ -1350,3 +1350,23 @@ Describe "Get-BinaryArchitecture-From-DLL" {
         }
     }
 }
+
+Describe "Run-Command" {
+    BeforeAll {
+        . "$PSScriptRoot\..\src\functions\helpers.ps1"
+    }
+
+    Context "When executing elevated commands" {
+        It "Passes -NoProfile to prevent user profile from loading" {
+            $mockProcess = [PSCustomObject]@{ ExitCode = 0 }
+            $mockProcess | Add-Member -MemberType ScriptMethod -Name WaitForExit -Value {}
+            Mock Start-Process { return $mockProcess }
+
+            $result = Run-Command -command "echo test"
+
+            Should -Invoke Start-Process -Times 1 -ParameterFilter {
+                $ArgumentList -like "*-NoProfile*"
+            }
+        }
+    }
+}

--- a/tests/helpers.tests.ps1
+++ b/tests/helpers.tests.ps1
@@ -1352,10 +1352,6 @@ Describe "Get-BinaryArchitecture-From-DLL" {
 }
 
 Describe "Run-Command" {
-    BeforeAll {
-        . "$PSScriptRoot\..\src\functions\helpers.ps1"
-    }
-
     Context "When executing elevated commands" {
         It "Passes -NoProfile to prevent user profile from loading" {
             $mockProcess = [PSCustomObject]@{ ExitCode = 0 }


### PR DESCRIPTION
## Summary

`Run-Command` spawns `powershell.exe` with `-Verb RunAs` but loads the user's profile. If the profile contains interactive commands (e.g. a PS5→PS7 redirect), the hidden window hangs indefinitely.

Adding `-NoProfile` fixes this: an elevated subprocess running a single command has no need for user profiles.

## Test plan

- [x] Added test verifying `-NoProfile` is passed to `Start-Process`
- [x] All 103 helpers tests pass